### PR TITLE
循环匹配解析记录类型，支持同时使用A记录和AAAA记录

### DIFF
--- a/update_aliyun_com.sh
+++ b/update_aliyun_com.sh
@@ -196,29 +196,43 @@ enable_domain() {
 
 # 获取子域名解析记录列表
 describe_domain() {
-	local value type; local ret=0
+	local count value; local ret=0
 	aliyun_transfer "Action=DescribeSubDomainRecords" "SubDomain=${__HOST}.${__DOMAIN}" || write_log 14 "服务器通信失败"
+	write_log 7 "获取到解析记录: $(cat "$DATFILE" 2> /dev/null)" 
 	json_cleanup; json_load "$(cat "$DATFILE" 2> /dev/null)" >/dev/null 2>&1
-	json_get_var value "TotalCount"
-	if [ $value -eq 0 ]; then
+	json_get_var count "TotalCount"
+	if [ $count -eq 0 ]; then
 		write_log 7 "解析记录不存在"
 		ret=1
 	else
-		json_select "DomainRecords" >/dev/null 2>&1
-		json_select "Record" >/dev/null 2>&1
-		json_select 1 >/dev/null 2>&1
-		json_get_var value "Locked"
-		[ $value -ne 0 ] && write_log 14 "解析记录被锁定"
-		json_get_var __RECID "RecordId"
-		write_log 7 "获得解析记录ID: ${__RECID}"
-		json_get_var value "Status"
-		[ "$value" != "ENABLE" ] && ret=$(( $ret | 2 )) && write_log 7 "解析记录被禁用"
-		json_get_var type "Type"
-		json_get_var value "Value"
-		[ "$type" != "${__TYPE}" -o "$value" != "${__IP}" ] && ret=$(( $ret | 4 )) && write_log 7 "地址或类型需要修改"
+		local i=1;
+		while [ $i -le $count ]; do
+			json_cleanup; json_load "$(cat "$DATFILE" 2> /dev/null)" >/dev/null 2>&1
+			json_select "DomainRecords" >/dev/null 2>&1
+			json_select "Record" >/dev/null 2>&1
+			json_select $i >/dev/null 2>&1
+			i=$(( $i + 1 ))
+			json_get_var value "Type"
+			if [ "$value" != "${__TYPE}" ]; then
+				write_log 7 "当前解析类型: ${__TYPE}, 获得不匹配类型: $value"
+				ret=1; continue
+			else
+				ret=0
+				json_get_var __RECID "RecordId"
+				write_log 7 "获得解析记录ID: ${__RECID}, 类型: $value"
+				json_get_var value "Locked"
+				[ $value -ne 0 ] && write_log 14 "解析记录被锁定"
+				json_get_var value "Status"
+				[ "$value" != "ENABLE" ] && ret=$(( $ret | 2 )) && write_log 7 "解析记录被禁用"
+				json_get_var value "Value"
+				[ "$value" != "${__IP}" ] && ret=$(( $ret | 4 )) && write_log 7 "地址需要修改"
+				break
+			fi
+		done
 	fi
 	return $ret
 }
+
 
 build_command
 describe_domain


### PR DESCRIPTION
我发现同时使用A记录和AAAA记录时会出现轮流修改的问题，原版只支持一个记录，如果解析类型不匹配对应类型就直接修改。
在此基础上我修改了匹配类型，如果没有匹配类型再新增一条记录，这样应该可以同时支持ipv4和ipv6解析。