### PR TITLE
解决IPv6记录更新错乱

### DIFF
--- a/update_aliyun_com.sh
+++ b/update_aliyun_com.sh
@@ -197,7 +197,7 @@ enable_domain() {
 # 获取子域名解析记录列表
 describe_domain() {
 	local value type; local ret=0
-	aliyun_transfer "Action=DescribeSubDomainRecords" "SubDomain=${__HOST}.${__DOMAIN}" || write_log 14 "服务器通信失败"
+	aliyun_transfer "Action=DescribeSubDomainRecords" "SubDomain=${__HOST}.${__DOMAIN}" "Type=${__TYPE}" || write_log 14 "服务器通信失败"
 	json_cleanup; json_load "$(cat "$DATFILE" 2> /dev/null)" >/dev/null 2>&1
 	json_get_var value "TotalCount"
 	if [ $value -eq 0 ]; then


### PR DESCRIPTION
在 describe_domain() 查询解析记录时，给阿里云的服务器多传一个 Type 参数，指定查询的是 IPv4 (A) 还是 IPv6 (AAAA) 记录，从而解决大家都在抱怨的 IP 地址更新”错位“问题。