### PR TITLE
Update update_aliyun_com.sh

### DIFF
--- a/update_aliyun_com.sh
+++ b/update_aliyun_com.sh
@@ -197,7 +197,7 @@ enable_domain() {
 # 获取子域名解析记录列表
 describe_domain() {
 	local value type; local ret=0
-	aliyun_transfer "Action=DescribeSubDomainRecords" "SubDomain=${__HOST}.${__DOMAIN}" "Type=${__TYPE}" || write_log 14 "服务器通信失败"
+	aliyun_transfer "Action=DescribeSubDomainRecords" "SubDomain=${__HOST}.${__DOMAIN}" "Type=${__TYPE}" "DomainName=${__DOMAIN}" || write_log 14 "服务器通信失败"
 	json_cleanup; json_load "$(cat "$DATFILE" 2> /dev/null)" >/dev/null 2>&1
 	json_get_var value "TotalCount"
 	if [ $value -eq 0 ]; then


### PR DESCRIPTION
添加DomainName参数，指定域名
用途： 为了安全，使用某个子域名用于解析 ddns ，比如 ddns.xxx.yyyy ，并且在权限管理中限制了只能修改这个域名下的内容。
不加这个参数，系统默认域名是 xxx.yyy 就会无法正常使用